### PR TITLE
f/create exception_transformer gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.byebug_history
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+---
+sudo: false
+language: ruby
+cache: bundler
+rvm:
+  - 2.5.1
+before_install: gem install bundler -v 1.17.3

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+# Specify your gem's dependencies in exception_transformer.gemspec
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,11 +2,21 @@ PATH
   remote: .
   specs:
     exception_transformer (0.1.0)
+      activesupport (~> 5)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.1.4)
     diff-lcs (1.3)
+    i18n (1.5.3)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -21,6 +31,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,35 @@
+PATH
+  remote: .
+  specs:
+    exception_transformer (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.3)
+    rake (10.5.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.17)
+  exception_transformer!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+
+BUNDLED WITH
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     exception_transformer (0.1.0)
-      activesupport (~> 5)
+      activesupport (~> 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -12,6 +12,7 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    byebug (10.0.2)
     concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     i18n (1.5.3)
@@ -40,6 +41,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
+  byebug (~> 10.0)
   exception_transformer!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    byebug (10.0.2)
     concurrent-ruby (1.1.4)
     diff-lcs (1.3)
     i18n (1.5.3)
@@ -41,7 +40,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.17)
-  byebug (~> 10.0)
   exception_transformer!
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # exception-transformer
 
+# Crash Reporter
+A crash reporter should be configured during the gem setup.
+  ```ruby
+  ExceptionTransformer.configure do |config|
+    config.reporter = proc { |e| Raven.capture_exception(e) }
+  end
+  ```
+
 # Examples
 Add exceptions to be transformed in `handle_exceptions` block.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # exception-transformer
+Add exceptions to be transformed in `handle_exceptions` block.
 
-# Crash Reporter
-A crash reporter should be configured during the gem setup.
-  ```ruby
-  ExceptionTransformer.configure do |config|
-    config.reporter = proc { |e| Raven.capture_exception(e) }
-  end
-  ```
+Battle-tested in production at [Privy](https://www.privy.com).
 
 # Examples
-Add exceptions to be transformed in `handle_exceptions` block.
 
 1. Transform several errors to a single error:
   ```ruby
@@ -36,4 +30,12 @@ first parameter is the response, and the second is the calling method.
 first parameter is the error, and the second is the calling method.
   ```ruby
   transform_exceptions with: proc { |err, action| ... }
+  ```
+
+# Crash Reporter
+A crash reporter should be configured during the gem setup.
+  ```ruby
+  ExceptionTransformer.configure do |config|
+    config.reporter = proc { |e| Raven.capture_exception(e) }
+  end
   ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # exception-transformer
+
+# Examples
+Add exceptions to be transformed in `handle_exceptions` block.
+
+1. Transform several errors to a single error:
+  ```ruby
+  transform_exceptions FooError, BazError, to: BarError
+  ```
+
+2. Transform a single error based on it's message:
+  ```ruby
+  transform_exceptions FooError, where: {
+    /Invalid API key/i => BarError,
+    :default => RuntimeError
+  }
+  ```
+  To prevent *all* errors being caught via the `:default` branch,
+  pass `use_default: false` to `handle_exceptions`.
+
+3. Validate a response with a Proc that takes two parameters. The
+first parameter is the response, and the second is the calling method.
+  ```ruby
+  transform_exceptions validate: proc { |response, action| ... }
+  ```
+
+4. Inspect an error with a Proc that takes two parameters. The
+first parameter is the error, and the second is the calling method.
+  ```ruby
+  transform_exceptions with: proc { |err, action| ... }
+  ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -1,0 +1,20 @@
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'exception_transformer/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'exception_transformer'
+  spec.version       = ExceptionTransformer::VERSION
+  spec.authors       = ['Patrick McLaren', 'Allina Dolor']
+  spec.email         = ['patrick@privy.com', 'allina@privy.com']
+
+  spec.summary       = 'Add exceptions to be transformed'
+  spec.description   = ''
+  spec.homepage      = 'https://github.com/Privy/exception-transformer'
+  spec.license       = 'MIT'
+
+  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+end

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'exception_transformer/version'
@@ -9,12 +8,15 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Patrick McLaren', 'Allina Dolor']
   spec.email         = ['patrick@privy.com', 'allina@privy.com']
 
-  spec.summary       = 'Add exceptions to be transformed'
-  spec.description   = ''
+  spec.summary       = 'Error Handling'
+  spec.description   = 'Add exceptions to be transformed.'
+  spec.files         =  Dir.glob('{lib,spec}/**/*')
   spec.homepage      = 'https://github.com/Privy/exception-transformer'
   spec.license       = 'MIT'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+
+  spec.add_dependency 'activesupport', '~> 5'
 end

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'byebug', '~> 10.0'
 
-  spec.add_dependency 'activesupport', '~> 5'
+  spec.add_dependency 'activesupport', '~> 5.0'
 end

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -11,13 +11,12 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Error Handling'
   spec.description   = 'Add exceptions to be transformed.'
   spec.files         =  Dir.glob('{lib,spec}/**/*')
-  spec.homepage      = 'https://github.com/Privy/exception-transformer'
+  spec.homepage      = 'https://github.com/Privy/exception_transformer'
   spec.license       = 'MIT'
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'byebug', '~> 10.0'
 
   spec.add_dependency 'activesupport', '~> 5.0'
 end

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['patrick@privy.com', 'allina@privy.com']
 
   spec.summary       = 'Error Handling'
-  spec.description   = 'Add exceptions to be transformed.'
+  spec.description   = 'Transform exceptions and send to a crash reporter'
   spec.files         =  Dir.glob('{lib,spec}/**/*')
   spec.homepage      = 'https://github.com/Privy/exception_transformer'
   spec.license       = 'MIT'

--- a/lib/exception_transformer.rb
+++ b/lib/exception_transformer.rb
@@ -1,0 +1,77 @@
+require "exception_transformer/version"
+
+
+module ExceptionTransformer
+  def self.included base
+    base.send :include, InstanceMethods
+    base.extend ClassMethods
+  end
+
+  module ClassMethods
+    # Add exceptions to be transformed in `handle_exceptions` block.
+    # @examples
+    #   1. Transform several errors to a single error:
+    #
+    #        transform_exceptions FooError, BazError, to: BarError
+    #
+    #   2. Transform a single error based on it's message:
+    #
+    #        transform_exceptions FooError, where: {
+    #          /Invalid API key/i => BarError,
+    #          :default => RuntimeError
+    #        }
+    #
+    #      To prevent *all* errors being caught via the `:default` branch,
+    #      pass `use_default: false` to `handle_exceptions`.
+    #
+    #   3. Validate a response with a Proc that takes two parameters. The
+    #      first parameter is the response, and the second is the calling method.
+    #
+    #         transform_exceptions validate: proc { |response, action| ... }
+    #
+    #   4. Inspect an error with a Proc that takes two parameters. The
+    #      first parameter is the error, and the second is the calling method.
+    #
+    #         transform_exceptions with: proc { |err, action| ... }
+    def transform_exceptions(*exceptions, group: :default, to: nil, where: nil, with: nil, validate: nil)
+      strategies = { validate: validate, delegate: with, rewrite: to, regex: where }
+
+      strategy = strategies.keys.find { |s| strategies[s].present? }
+      target   = strategies[strategy]
+
+      transformer = find_or_create_exception_transformer(group, strategy)
+      transformer.register_target(target, exceptions)
+    end
+
+    def find_exception_transformer(group)
+      exception_transformers[group]
+    end
+
+    def find_or_create_exception_transformer(group, strategy)
+      exception_transformers[group] ||= Transformer.new(strategy)
+    end
+
+    private
+
+    def exception_transformers
+      @exception_transformers ||= {}
+    end
+  end
+
+  module InstanceMethods
+    def handle_exceptions(group = :default, **opts)
+      # NOTE: `base_label` returns the label of this frame without decoration,
+      # i.e. if `label` was 'block in test', then `base_label` would be `test`.
+      calling_method = caller_locations(1, 1)[0].base_label
+      transformer    = self.class.find_exception_transformer(group)
+
+      result = yield
+
+      transformer.after_yield(self, result, calling_method, opts)
+
+      result
+    rescue => e
+      transformer.after_rescue(self, e, calling_method, opts)
+    end
+  end
+end

--- a/lib/exception_transformer.rb
+++ b/lib/exception_transformer.rb
@@ -1,5 +1,8 @@
-require "exception_transformer/version"
+require 'exception_transformer/version'
+require 'exception_transformer/transformer'
 
+require 'active_support'
+require 'active_support/core_ext'
 
 module ExceptionTransformer
   def self.included base

--- a/lib/exception_transformer.rb
+++ b/lib/exception_transformer.rb
@@ -1,12 +1,11 @@
+# frozen_string_literal: true
+
 require 'exception_transformer/version'
 require 'exception_transformer/config'
 require 'exception_transformer/transformer'
 
 require 'active_support'
 require 'active_support/core_ext'
-
-# TODO: remove byebug
-require 'byebug'
 
 module ExceptionTransformer
   attr_accessor :config
@@ -16,8 +15,8 @@ module ExceptionTransformer
     base.extend ClassMethods
   end
 
+  # To send exceptions to a crash reporter, implement a configuration block:
   # @example
-  # Can take a configuration block:
   #   ExceptionTransformer.configure do |config|
   #     config.reporter = proc { |e| Raven.capture_exception(e) }
   #   end
@@ -26,7 +25,7 @@ module ExceptionTransformer
   end
 
   def self.config
-    @reporter ||= Config.new
+    @config ||= Config.new
   end
 
   module ClassMethods

--- a/lib/exception_transformer/config.rb
+++ b/lib/exception_transformer/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExceptionTransformer::Config
   attr_accessor :reporter
 

--- a/lib/exception_transformer/config.rb
+++ b/lib/exception_transformer/config.rb
@@ -1,0 +1,7 @@
+class ExceptionTransformer::Config
+  attr_accessor :reporter
+
+  def initialize
+    self.reporter ||= proc { |e| }
+  end
+end

--- a/lib/exception_transformer/reportable.rb
+++ b/lib/exception_transformer/reportable.rb
@@ -1,0 +1,102 @@
+module ExceptionTransformer
+  # Include this module when declaring an exception class to add
+  # the `reportable?` flag to individual exceptions. The presence
+  # of this flag can then be checked when capturing exceptions to
+  # send to a crash reporter.
+  #
+  # @example Conditionally reporting exceptions
+  #   class MyError < StandardError
+  #     include ExceptionTransformer::ReportableException
+  #   end
+  #
+  #   begin
+  #     # do something that may fail
+  #   rescue MyError => e
+  #     CrashReport.new(e) if e.reportable?
+  #   end
+  #
+  # This flag can be set at the instance level with `mark_reportable!`.
+  # Alternatively, the class method `as_reportable` returns a subclass
+  # for which `reportable?` is true when raised.
+  module Reportable
+    def self.included(base)
+      raise TypeError, "#{base} is not a type of Exception" unless base <= Exception
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      # Returns a subclass 'Reportable_<name>' of the current class that
+      # includes `Reportable`. This subclass is created the first time
+      # time this method is called and reused for subsequent invocations.
+      def as_reportable
+        return self if self <= ReportableException
+
+        name = reportable_name
+        mod  = parent
+
+        mod.const_defined?(name) ? mod.const_get(name) : mod.const_set(name, build_reportable)
+      end
+
+      def unload_reportable
+        name = reportable_name
+        mod  = parent
+
+        mod.send(:remove_const, name) if mod.const_defined?(name)
+      end
+
+      def reported_class
+        @reported_class ||= self
+      end
+
+      def reported_class=(klass)
+        @reported_class = klass
+      end
+
+      private
+
+      def build_reportable
+        super_class = self
+        Class.new(super_class) do
+          include ReportableException
+          self.reported_class = super_class
+        end
+      end
+
+      def reportable_name
+        [ReportableException.name, self.name].map(&:demodulize).join("_")
+      end
+    end
+
+    def reportable?
+      @reportable ||= false
+    end
+
+    def mark_reportable!
+      @reportable = true
+    end
+  end
+
+  # Every `Reportable` that includes `ReportableException` will be
+  # raised with the `reportable?` flag set to true.
+  module ReportableException
+    def self.included(base)
+      base.include(Reportable) unless base <= Reportable
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def exception(*args)
+        if reported_class == self
+          super.tap(&:mark_reportable!)
+        else
+          reported_class.exception(*args).tap(&:mark_reportable!)
+        end
+      end
+    end
+
+    def exception(*args)
+      mark_reportable!
+      super
+    end
+  end
+end

--- a/lib/exception_transformer/reportable.rb
+++ b/lib/exception_transformer/reportable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ExceptionTransformer
   # Include this module when declaring an exception class to add
   # the `reportable?` flag to individual exceptions. The presence

--- a/lib/exception_transformer/transformer.rb
+++ b/lib/exception_transformer/transformer.rb
@@ -1,0 +1,91 @@
+class ExceptionTransformer::Transformer
+  attr_accessor :strategy, :validator, :delegate, :mappings
+
+  MAX_MESSAGE_SIZE = 100
+
+  def initialize(strategy)
+    self.strategy = strategy
+    self.mappings = {}
+  end
+
+  def register_target(target, exceptions)
+    case strategy
+    when :validate
+      self.validator = target
+    when :delegate
+      self.delegate  = target
+    when :rewrite, :regex
+      exceptions.each do |klass|
+        self.mappings[klass] = target
+      end
+    end
+  end
+
+  def after_rescue(obj, e, calling_method, except: [], use_default: true, opts: {})
+    with_reporting do
+      case strategy
+      when :delegate
+        obj.instance_exec(e, calling_method, opts, &delegate)
+      when :rewrite, :regex
+        exception, message = find_target(e, except, use_default)
+      end
+
+      if exception.present?
+        raise exception, message.first(MAX_MESSAGE_SIZE), e.backtrace
+      else
+        # Couldn't transform the exception to a defined mapping.
+        raise e
+      end
+    end
+  end
+
+  def after_yield(obj, result, calling_method, except: [], use_default: true, opts: {})
+    with_reporting do
+      case strategy
+      when :validate
+        obj.instance_exec(result, calling_method, opts, &validator)
+      end
+    end
+  end
+
+  private
+
+  # @return [Array] `[exception, message]`
+  def find_target(e, exclude, use_default_match)
+    case strategy
+    when :rewrite
+      exception = find_mapping(e, exclude)
+      message   = e.message
+    when :regex
+      patterns  = find_mapping(e, exclude) || {}
+
+      pattern = patterns.keys.find { |re| re.is_a?(Regexp) && e.message =~ re }
+      pattern ||= :default if use_default_match
+
+      exception = patterns[pattern]
+      message   = e.message.length <= MAX_MESSAGE_SIZE ? e.message : pattern.inspect.gsub(/([^\w\s]|i\z)*/, '')
+    end
+
+    [exception, message]
+  end
+
+  # @return [StandardError, Hash]
+  def find_mapping(e, exclude)
+    mappings
+      .select  { |klass| e.is_a?(klass) && !exclude.include?(klass) }
+      .sort_by { |klass, _| klass.ancestors.count }
+      .last.try(:[], 1)
+  end
+
+  # Report all exceptions that occur except those
+  # with the `reportable?` flag set to false.
+  def with_reporting
+    yield
+  rescue => e
+    unless e.respond_to?(:reportable?) && !e.reportable?
+      Raven.capture_exception(e)
+    end
+
+    raise
+  end
+end

--- a/lib/exception_transformer/transformer.rb
+++ b/lib/exception_transformer/transformer.rb
@@ -85,7 +85,7 @@ class ExceptionTransformer::Transformer
     yield
   rescue => e
     unless e.respond_to?(:reportable?) && !e.reportable?
-      ExceptionTransformer.config.reporter
+      ExceptionTransformer.config.reporter.call(e)
     end
 
     raise

--- a/lib/exception_transformer/transformer.rb
+++ b/lib/exception_transformer/transformer.rb
@@ -83,8 +83,7 @@ class ExceptionTransformer::Transformer
     yield
   rescue => e
     unless e.respond_to?(:reportable?) && !e.reportable?
-      # @examples
-      #   Raven.capture_exception(e)
+      ExceptionTransformer.config
     end
 
     raise

--- a/lib/exception_transformer/transformer.rb
+++ b/lib/exception_transformer/transformer.rb
@@ -83,7 +83,8 @@ class ExceptionTransformer::Transformer
     yield
   rescue => e
     unless e.respond_to?(:reportable?) && !e.reportable?
-      Raven.capture_exception(e)
+      # @examples
+      #   Raven.capture_exception(e)
     end
 
     raise

--- a/lib/exception_transformer/transformer.rb
+++ b/lib/exception_transformer/transformer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ExceptionTransformer::Transformer
   attr_accessor :strategy, :validator, :delegate, :mappings
 
@@ -83,7 +85,7 @@ class ExceptionTransformer::Transformer
     yield
   rescue => e
     unless e.respond_to?(:reportable?) && !e.reportable?
-      ExceptionTransformer.config
+      ExceptionTransformer.config.reporter
     end
 
     raise

--- a/lib/exception_transformer/version.rb
+++ b/lib/exception_transformer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ExceptionTransformer
   VERSION = "0.1.0"
 end

--- a/lib/exception_transformer/version.rb
+++ b/lib/exception_transformer/version.rb
@@ -1,0 +1,3 @@
+module ExceptionTransformer
+  VERSION = "0.1.0"
+end

--- a/spec/exception_transformer/reportable_spec.rb
+++ b/spec/exception_transformer/reportable_spec.rb
@@ -1,0 +1,106 @@
+require 'exception_transformer/reportable'
+require 'helpers/class_helpers'
+
+describe ExceptionTransformer::Reportable do
+  include ClassHelpers
+
+  context 'when included' do
+    context 'in a class that is not an Exception' do
+      before(:each) { build_class :NotAnException }
+
+      it 'raises TypeError' do
+        expect { NotAnException.include ExceptionTransformer::Reportable }
+          .to raise_error(TypeError)
+      end
+    end
+
+    context 'in an Exception' do
+      before(:each) { build_class :MyException, Exception }
+
+      it 'it should extend it with class methods' do
+        expect { MyException.include ExceptionTransformer::Reportable }
+          .to change { MyException.singleton_class.ancestors }
+          .to include(ExceptionTransformer::Reportable::ClassMethods)
+      end
+    end
+  end
+
+  shared_context :reportable, define_reportable: true do
+    before(:each) do
+      build_class :MyException, Exception do
+        include ExceptionTransformer::Reportable
+      end
+    end
+
+    after(:each) { MyException.unload_reportable }
+  end
+
+  describe '::as_reportable', define_reportable: true do
+    it 'returns a subclass of ReportableException' do
+      expect(MyException.as_reportable).to be < ExceptionTransformer::ReportableException
+    end
+
+    it 'is idempotent' do
+      reportable_exception = MyException.as_reportable
+      expect(reportable_exception).to equal(reportable_exception.as_reportable)
+    end
+
+    describe 'the return value' do
+      it 'is a subclass of the caller' do
+        expect(MyException.as_reportable).to be < MyException
+      end
+
+      it 'is a constant' do
+        expect(MyException.as_reportable.name).not_to be_nil
+      end
+
+      context 'when raised' do
+        it 'is reportable' do
+          expect { raise MyException.as_reportable, 'oops!' }.to raise_error(be_reportable, 'oops!')
+        end
+      end
+    end
+  end
+
+  describe '::unload_reportable', define_reportable: true do
+    context 'when the reportable exception is defined' do
+      it 'removes the constant' do
+        reportable_exception = MyException.as_reportable
+        MyException.unload_reportable
+        expect(Object.const_defined?(reportable_exception.name)).to be false
+      end
+
+      it 'returns it' do
+        reportable_exception = MyException.as_reportable
+        expect(MyException.unload_reportable).to equal(reportable_exception)
+      end
+    end
+
+    context 'when the reportable exception is not defined' do
+      it 'returns nil' do
+        expect(MyException.unload_reportable).to be_nil
+      end
+    end
+  end
+
+  describe '#reportable?', define_reportable: true do
+    context 'when ReportableException is not included' do
+      context 'when the exception is raised' do
+        it 'is false' do
+          # assert !MyException.include?(ExceptionTransformer::ReportableException)
+          expect { raise MyException.new }.to raise_error do |e|
+            expect(e).not_to be_reportable
+          end
+        end
+      end
+    end
+  end
+
+  describe '#mark_reportable!', define_reportable: true do
+    it 'marks the exception as reportable' do
+      exception = MyException.new
+      expect { exception.mark_reportable! }
+        .to change { exception.reportable? }.from(false).to(true)
+    end
+  end
+end

--- a/spec/exception_transformer_spec.rb
+++ b/spec/exception_transformer_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe ExceptionTransformer do
+  it "has a version number" do
+    expect(ExceptionTransformer::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/exception_transformer_spec.rb
+++ b/spec/exception_transformer_spec.rb
@@ -1,9 +1,291 @@
-RSpec.describe ExceptionTransformer do
-  it "has a version number" do
-    expect(ExceptionTransformer::VERSION).not_to be nil
+require 'exception_transformer'
+
+describe ExceptionTransformer do
+  class FooError < StandardError; end
+  class BarError < StandardError; end
+
+  class BazError < StandardError; end
+  class QuxError < StandardError; end
+
+  class ClassWithExceptionTransformer
+    include ExceptionTransformer
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  def build_obj(&block)
+    Class.new(ClassWithExceptionTransformer, &block).new
+  end
+
+  it 'returns the result if there are no errors' do
+    obj = build_obj do
+      transform_exceptions FooError, to: BarError
+      def task; :task end
+    end
+
+    expect(obj.task).to be(:task)
+  end
+
+  it 'should preserve exception messages' do
+    obj = build_obj do
+      transform_exceptions FooError, to: BarError
+
+      def task; handle_exceptions { raise FooError, 'oops' } end
+    end
+
+    expect{obj.task}.to raise_error(BarError, 'oops')
+  end
+
+  context 'when using :validate strategy' do
+    it 'transforms exceptions' do
+      obj = build_obj do
+        transform_exceptions validate: proc { |res, action|
+          unless res == :success
+            fail FooError
+          end
+        }
+
+        def task1; handle_exceptions { :success } end
+        def task2; handle_exceptions { :failure } end
+      end
+
+      expect{obj.task1}.not_to raise_error
+      expect{obj.task2}.to raise_error(FooError)
+    end
+
+    it 'executes the proc in instance context' do
+      obj = build_obj do
+        transform_exceptions validate: proc { |res, action|
+          raise FooError unless @foo
+        }
+
+        def task1; handle_exceptions { @foo = :foo } end
+        def task2; handle_exceptions { @foo = nil  } end
+      end
+
+      expect{obj.task1}.not_to raise_error
+      expect{obj.task2}.to raise_error(FooError)
+    end
+  end
+
+  context 'when using :delegate strategy' do
+    it 'transforms exceptions' do
+      obj = build_obj do
+        transform_exceptions with: proc { |e, action|
+          next unless e.is_a? FooError
+          raise BazError
+        }
+
+        def task1; handle_exceptions { raise FooError } end
+        def task2; handle_exceptions { raise BarError } end
+      end
+
+      expect{obj.task1}.to raise_error(BazError)
+      expect{obj.task2}.to raise_error(BarError)
+    end
+
+    it 'executes the proc in instance context' do
+      obj = build_obj do
+        transform_exceptions with: proc { |err, action|
+          if @foo
+            raise FooError
+          else
+            raise BarError
+          end
+        }
+
+        def task1
+          handle_exceptions do
+            @foo = :foo
+            raise
+          end
+        end
+
+        def task2
+          handle_exceptions do
+            @foo = nil
+            raise
+          end
+        end
+      end
+
+      expect{obj.task1}.to raise_error(FooError)
+      expect{obj.task2}.to raise_error(BarError)
+    end
+
+    it 'doesnt decorate the caller_location label' do
+      obj = build_obj do
+        transform_exceptions with: proc { |res, action|
+          raise action
+        }
+
+        def task1
+          handle_exceptions { raise }
+        end
+
+        def task2
+          [:foo, :bar].each do |sym|
+            handle_exceptions { raise }
+          end
+        end
+      end
+
+      expect{obj.task1}.to raise_error('task1')
+      expect{obj.task2}.to raise_error('task2')
+    end
+  end
+
+  it 'should limit exception messages to certain length' do
+    obj = build_obj do
+      transform_exceptions FooError, to: BarError
+
+      def task; handle_exceptions { raise FooError, 'oops' * 50 } end
+    end
+
+    begin
+      obj.task
+    rescue BarError => e
+      expect(e.message.length).to be <= ExceptionTransformer::Transformer::MAX_MESSAGE_SIZE
+    end
+  end
+
+  context 'when using :rewrite strategy' do
+    it 'transforms exceptions' do
+      obj = build_obj do
+        transform_exceptions FooError, to: BarError
+
+        def task; handle_exceptions { raise FooError } end
+      end
+
+      expect{obj.task}.to raise_error(BarError)
+    end
+
+    it 'transforms exceptions by inheritance order' do
+      obj = build_obj do
+        transform_exceptions FooError, to: BarError
+        transform_exceptions StandardError, to: QuxError
+
+        def task1; handle_exceptions { raise FooError } end
+        def task2; handle_exceptions { raise ArgumentError} end
+      end
+
+      expect{obj.task1}.to raise_error(BarError)
+      expect{obj.task2}.to raise_error(QuxError)
+    end
+
+    it 'doesnt transform exceptions to be skipped' do
+      obj = build_obj do
+        transform_exceptions FooError, to: BarError
+
+        def task; handle_exceptions(except: [FooError]) { raise FooError, 'oops' } end
+      end
+
+      expect{obj.task}.to raise_error(FooError)
+    end
+  end
+
+  context 'when using :regex strategy' do
+    it 'is able to transform exceptions' do
+      obj = build_obj do
+        transform_exceptions FooError, where: {
+                               /oops/ => BarError,
+                               :default  => StandardError
+                             }
+
+        def task1; handle_exceptions { raise FooError, 'oops' } end
+        def task2; handle_exceptions { raise FooError } end
+      end
+
+      expect{obj.task1}.to raise_error(BarError)
+      expect{obj.task2}.to raise_error(StandardError)
+    end
+
+    it 'should fallback to the default transformation unless specified' do
+      obj = build_obj do
+        transform_exceptions FooError, where: {
+                               /oops/ => BarError,
+                               :default  => StandardError
+                             }
+
+        def task1; handle_exceptions { raise FooError, 'oops' } end
+
+        def task2
+          handle_exceptions use_default: false do
+            raise FooError
+          end
+        end
+      end
+
+      expect{obj.task1}.to raise_error(BarError)
+      expect{obj.task2}.to raise_error(FooError)
+    end
+
+    it 'should keep the exception message if < 100 characters' do
+      obj = build_obj do
+        transform_exceptions FooError, where: {
+          /oops/ => BarError,
+          :default  => StandardError
+        }
+
+        def task1; handle_exceptions { raise FooError, 'oops it broke' } end
+      end
+
+      begin
+        obj.task1
+      rescue BarError => e
+        expect(e.message).to eq('oops it broke')
+      end
+    end
+
+    it 'should use a readable version of the regex if message > 100 characters' do
+      obj = build_obj do
+        transform_exceptions FooError, where: {
+          /oops/ => BarError,
+          :default  => StandardError
+        }
+
+        def task1; handle_exceptions { raise FooError, 'oops' + ((0..9).to_a.join * 10) } end
+      end
+
+      begin
+        obj.task1
+      rescue BarError => e
+        expect(e.message).to eq('oops')
+      end
+    end
+  end
+
+  describe '::find_exception_transformer' do
+    let!(:obj) do
+      build_obj do
+        transform_exceptions FooError, to: BarError, group: :a
+        transform_exceptions FooError, to: BazError, group: :b
+      end
+    end
+
+    it 'returns the transformer defined for the given group' do
+      transformer = obj.class.find_exception_transformer(:a)
+
+      expect(transformer).to be
+      expect(transformer.mappings).to eq(FooError => BarError)
+    end
+  end
+
+  describe '#handle_exceptions' do
+    context 'when a group is provided' do
+      let!(:obj) do
+        build_obj do
+          transform_exceptions FooError, to: BarError, group: :a
+          transform_exceptions FooError, to: BazError, group: :b
+
+          def task(group)
+            handle_exceptions(group) { raise FooError }
+          end
+        end
+      end
+
+      it 'should use the transformer defined for the given group' do
+        expect { obj.task(:a) }.to raise_error(BarError)
+        expect { obj.task(:b) }.to raise_error(BazError)
+      end
+    end
   end
 end

--- a/spec/exception_transformer_spec.rb
+++ b/spec/exception_transformer_spec.rb
@@ -1,4 +1,4 @@
-require 'exception_transformer'
+# frozen_string_literal: true
 
 describe ExceptionTransformer do
   class FooError < StandardError; end

--- a/spec/helpers/class_helpers.rb
+++ b/spec/helpers/class_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ClassHelpers
   # Defines a named class, descending from `super_class`.
   # The constant assigned to the the class will be restored

--- a/spec/helpers/class_helpers.rb
+++ b/spec/helpers/class_helpers.rb
@@ -1,0 +1,13 @@
+module ClassHelpers
+  # Defines a named class, descending from `super_class`.
+  # The constant assigned to the the class will be restored
+  # to it's original state when an example completes.
+  #
+  # @param name [Symbol, String] the constant name
+  # @param super_class [Class] the class the return value inherits from
+  # @yield [] block passed to `Class.new`
+  # @return [Class]
+  def build_class(name, super_class = Object, &block)
+    stub_const(name.to_s, Class.new(super_class, &block))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,6 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.expose_dsl_globally = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "exception_transformer"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Extracts `exception_transformer` files into lib directory.

![screenshot from 2019-01-29 10-42-28](https://user-images.githubusercontent.com/22645679/51921061-a7ee2b80-23b4-11e9-820e-74e9cd8a4aa0.png)

# Post-deployment
1. Update version + tag commit
2. Publish gem to RubyGems
3. `gem install exception-transformer` and use gem in codebase