### PR TITLE
Bug/uninitialized constant

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    exception_transformer (0.1.0)
+    exception_transformer (1.0.0)
       activesupport (~> 5.0)
 
 GEM

--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email         = ['patrick@privy.com', 'allina@privy.com']
 
   spec.summary       = 'Error Handling'
-  spec.description   = 'Transform exceptions and send to a crash reporter'
+  spec.description   = 'Transform exceptions and send to a crash reporter.'
   spec.files         =  Dir.glob('{lib,spec}/**/*')
   spec.homepage      = 'https://github.com/Privy/exception_transformer'
   spec.license       = 'MIT'

--- a/lib/exception_transformer.rb
+++ b/lib/exception_transformer.rb
@@ -3,6 +3,7 @@
 require 'exception_transformer/version'
 require 'exception_transformer/config'
 require 'exception_transformer/transformer'
+require 'exception_transformer/reportable'
 
 require 'active_support'
 require 'active_support/core_ext'

--- a/lib/exception_transformer/reportable.rb
+++ b/lib/exception_transformer/reportable.rb
@@ -29,7 +29,7 @@ module ExceptionTransformer
     module ClassMethods
       # Returns a subclass 'Reportable_<name>' of the current class that
       # includes `Reportable`. This subclass is created the first time
-      # time this method is called and reused for subsequent invocations.
+      # this method is called and reused for subsequent invocations.
       def as_reportable
         return self if self <= ReportableException
 

--- a/lib/exception_transformer/version.rb
+++ b/lib/exception_transformer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ExceptionTransformer
-  VERSION = "0.1.0"
+  VERSION = "1.0.0"
 end


### PR DESCRIPTION
Fixes #2 

Fixes `NameError: uninitialized constant ExceptionTransformer::Reportable` error when running tests that use the gem.
Also fixes minor typos.

After fix: 
![passing](https://user-images.githubusercontent.com/22645679/52745425-f6065000-2fac-11e9-9a4d-ee098c040135.png)
![irb](https://user-images.githubusercontent.com/22645679/52745435-01597b80-2fad-11e9-85e5-16e7ff0a3ae8.png)

**Testing:**
1. Install gem from RubyGems locally
2. Unpack installed gem into our `vendor/gems` in our app
      - If it successfully unpacks, add `gem 'exception_transformer', '1.0.0', :path => '/app/vendor/gems/exception_transformer/exception_transformer-1.0.0'` in our gemfile
3. Experiment by adding/removing `require 'exception_transformer/reportable'` in `exception_transformer.rb`



