### PR TITLE
Rails6 support

### DIFF
--- a/exception_transformer.gemspec
+++ b/exception_transformer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
-  spec.add_dependency 'activesupport', '~> 5.0'
+  spec.add_dependency 'activesupport', '>= 5.0', '< 7'
 end

--- a/lib/exception_transformer/reportable.rb
+++ b/lib/exception_transformer/reportable.rb
@@ -34,14 +34,14 @@ module ExceptionTransformer
         return self if self <= ReportableException
 
         name = reportable_name
-        mod  = parent
+        mod = self.respond_to?(:module_parent) ? module_parent : parent
 
         mod.const_defined?(name) ? mod.const_get(name) : mod.const_set(name, build_reportable)
       end
 
       def unload_reportable
         name = reportable_name
-        mod  = parent
+        mod = self.respond_to?(:module_parent) ? module_parent : parent
 
         mod.send(:remove_const, name) if mod.const_defined?(name)
       end


### PR DESCRIPTION
- loosen activesupport dependency to allow 6.x
- fix deprecation warning on rails6